### PR TITLE
no linebreak after <pre> in content.html

### DIFF
--- a/tests/11.json
+++ b/tests/11.json
@@ -10,7 +10,7 @@
                 ],
                 "content": [
                     {
-                        "html": "Hello World\n    <pre>\n      one\n      two\n      three\n    </pre>",
+                        "html": "Hello World\n    <pre>      one\n      two\n      three\n    </pre>",
                         "value": "Hello World\n      one\n      two\n      three"
                     }
                 ]


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element says "In the HTML syntax, a leading newline character immediately following the pre element start tag is stripped."