### PR TITLE
Add tests showing <pre> on same line as other content

### DIFF
--- a/tests/13.html
+++ b/tests/13.html
@@ -1,0 +1,8 @@
+<div class="h-entry">
+  <div class="e-content p-name">
+    Hello World <pre>
+      one
+      two
+      three</pre> And Hello Mars!
+  </div>
+</div>

--- a/tests/13.json
+++ b/tests/13.json
@@ -1,0 +1,20 @@
+{
+    "items": [
+        {
+            "type": [
+                "h-entry"
+            ],
+            "properties": {
+                "name": [
+                    "Hello World\n      one\n      two\n      three\nAnd Hello Mars"
+                ],
+                "content": [
+                    {
+                        "html": "Hello World <pre>\n      one\n      two\n      three\n    </pre> And Hello Mars",
+                        "value": "Hello World\n      one\n      two\n      three\nAnd Hello Mars"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tests/14.html
+++ b/tests/14.html
@@ -1,0 +1,9 @@
+<div class="h-entry">
+  <div class="e-content p-name">
+    <p>Hello World</p> 
+    <pre>
+      one
+      two
+      three</pre> <p>And Hello Mars!</p>
+  </div>
+</div>

--- a/tests/14.json
+++ b/tests/14.json
@@ -1,0 +1,20 @@
+{
+    "items": [
+        {
+            "type": [
+                "h-entry"
+            ],
+            "properties": {
+                "name": [
+                    "Hello World\n      one\n      two\n      three\nAnd Hello Mars"
+                ],
+                "content": [
+                    {
+                        "html": "<p>Hello World</p> \n    <pre>\n      one\n      two\n      three\n    </pre> <p>And Hello Mars<p>",
+                        "value": "Hello World\n      one\n      two\n      three\nAnd Hello Mars"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Per recent discussions (https://github.com/microformats/microformats2-parsing/issues/15#issuecomment-407707386) and my proposal there to treat `<pre>` similar to `<p>` or `display: inline-block` as in browsers.

Screenshot of rendering in Chrome:
![image](https://user-images.githubusercontent.com/1082036/43231045-02eee84a-906b-11e8-81c1-66892c4c7bc0.png)
